### PR TITLE
Markdown report rendering

### DIFF
--- a/mythx_cli/templates/default.md
+++ b/mythx_cli/templates/default.md
@@ -49,3 +49,8 @@
 {% endfor %}
 {% endfor %}
 {% endblock %}
+
+{% block postamble %}
+----------
+Made with ♥ by [MythX CLI](https://github.com/dmuhs/mythx-cli)
+{% endblock %}

--- a/mythx_cli/templates/default.md
+++ b/mythx_cli/templates/default.md
@@ -22,14 +22,14 @@
 {% for loc in issue.locations %}
 {% if loc.source_format == "text" %}
 {% set source_file=loc.source_list[0] %}
-**Issue:** {{ issue.swc_id }} - {{ issue.swc_title }}
-**Severity:** {{ issue.severity|title }}
-**Description:** {{ issue.description_long }}
-**Location:** {{ source_file }}
+- **Issue:** {{ issue.swc_id }} - {{ issue.swc_title }}
+- **Severity:** {{ issue.severity|title }}
+- **Description:** {{ issue.description_long }}
+- **Location:** {{ source_file }}
 {% if loop.index0 < issue.decoded_locations|length and issue.decoded_locations[loop.index0].start_line %}
 {% set location=issue.decoded_locations[loop.index0] %}
-**Line:** {{ location.start_line }}
-**Column:** {{ location.start_column }}
+- **Line:** {{ location.start_line }}
+- **Column:** {{ location.start_column }}
 {% set source_data=input.sources[source_file]["source"].split("\n") %}
 
 ```
@@ -38,9 +38,11 @@
 {{ source_data[location.start_line]}}
 ```
 
+
 {% else %}
-**Line:** undefined
-**Column:** undefined
+- **Line:** *undefined*
+- **Column:** *undefined*
+
 
 {% endif %}
 {% endif %}

--- a/mythx_cli/templates/default.md
+++ b/mythx_cli/templates/default.md
@@ -4,12 +4,13 @@
 # MythX Report for {{ target }}
 {% endblock %}
 
-{% block preample %}{% endblock %}
-
-{% block status %}
+{% block header %}
 ##  Report for {{ input.sources.keys()|join(", ") }}
 [View on MythX Dashboard](https://dashboard.mythx.io/#/console/analyses/{{ report.uuid }})
 
+{% endblock %}
+
+{% block status %}
 | High | Medium | Low | Unknown |
 |------|--------|-----|---------|
 | {{ "%-4s" | format(status.vulnerability_statistics.high,) }} | {{ "%-6s" | format(status.vulnerability_statistics.medium,) }} | {{ "%-3s" | format(status.vulnerability_statistics.low,) }} | {{ "%-7s" | format(status.vulnerability_statistics.none,) }} |

--- a/mythx_cli/templates/default.md
+++ b/mythx_cli/templates/default.md
@@ -20,13 +20,7 @@
 {% for issue in report %}
 {% for loc in issue.locations %}
 {% if loc.source_format == "text" %}
-
-**Issue:** {{ issue.swc_id }} - {{ issue.swc_title }}
-{{ loop.index0 }}
-{{ issue.decoded_locations }}
-
-{#
-{% set location=issue.decoded_locations[0] %}
+{% set location=issue.decoded_locations[loop.index0] %}
 {% set source_file=loc.source_list[0] %}
 **Issue:** {{ issue.swc_id }} - {{ issue.swc_title }}
 **Severity:** {{ issue.severity|title }}
@@ -35,13 +29,12 @@
 **Line:** {{ location.start_line }}
 **Column:** {{ location.start_column }}
 {% set source_data=input.sources[source_file]["source"].split("\n") %}
+
 ```
 {{ source_data[location.start_line-2]}}
 {{ source_data[location.start_line-1]}}
 {{ source_data[location.start_line]}}
 ```
-
-#}
 
 {% endif %}
 {% endfor %}

--- a/mythx_cli/templates/default.md
+++ b/mythx_cli/templates/default.md
@@ -21,12 +21,13 @@
 {% for issue in report %}
 {% for loc in issue.locations %}
 {% if loc.source_format == "text" %}
-{% set location=issue.decoded_locations[loop.index0] %}
 {% set source_file=loc.source_list[0] %}
 **Issue:** {{ issue.swc_id }} - {{ issue.swc_title }}
 **Severity:** {{ issue.severity|title }}
 **Description:** {{ issue.description_long }}
 **Location:** {{ source_file }}
+{% if loop.index0 < issue.decoded_locations|length and issue.decoded_locations[loop.index0].start_line %}
+{% set location=issue.decoded_locations[loop.index0] %}
 **Line:** {{ location.start_line }}
 **Column:** {{ location.start_column }}
 {% set source_data=input.sources[source_file]["source"].split("\n") %}
@@ -37,6 +38,11 @@
 {{ source_data[location.start_line]}}
 ```
 
+{% else %}
+**Line:** undefined
+**Column:** undefined
+
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/mythx_cli/templates/default.md
+++ b/mythx_cli/templates/default.md
@@ -1,0 +1,49 @@
+{% extends "layout.md" %}
+
+{% block heading %}
+# MythX Report for {{ target }}
+{% endblock %}
+
+{% block preample %}{% endblock %}
+
+{% block status %}
+##  Report for {{ input.sources.keys()|join(", ") }}
+[View on MythX Dashboard](https://dashboard.mythx.io/#/console/analyses/{{ report.uuid }})
+
+| High | Medium | Low | Unknown |
+|------|--------|-----|---------|
+| {{ "%-4s" | format(status.vulnerability_statistics.high,) }} | {{ "%-6s" | format(status.vulnerability_statistics.medium,) }} | {{ "%-3s" | format(status.vulnerability_statistics.low,) }} | {{ "%-7s" | format(status.vulnerability_statistics.none,) }} |
+
+{% endblock %}
+
+{% block report %}
+{% for issue in report %}
+{% for loc in issue.locations %}
+{% if loc.source_format == "text" %}
+
+**Issue:** {{ issue.swc_id }} - {{ issue.swc_title }}
+{{ loop.index0 }}
+{{ issue.decoded_locations }}
+
+{#
+{% set location=issue.decoded_locations[0] %}
+{% set source_file=loc.source_list[0] %}
+**Issue:** {{ issue.swc_id }} - {{ issue.swc_title }}
+**Severity:** {{ issue.severity|title }}
+**Description:** {{ issue.description_long }}
+**Location:** {{ source_file }}
+**Line:** {{ location.start_line }}
+**Column:** {{ location.start_column }}
+{% set source_data=input.sources[source_file]["source"].split("\n") %}
+```
+{{ source_data[location.start_line-2]}}
+{{ source_data[location.start_line-1]}}
+{{ source_data[location.start_line]}}
+```
+
+#}
+
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endblock %}

--- a/mythx_cli/templates/layout.md
+++ b/mythx_cli/templates/layout.md
@@ -1,11 +1,15 @@
 {% block heading scoped %}{% endblock %}
 {% block preamble scoped %}{% endblock %}
 {% for status, report, input in issues_list %}
+{% block header scoped %}{% endblock %}
 {% if report %}
 {% block status scoped %}{% endblock %}
 {% block report scoped %}{% endblock %}
 {% else %}
-{% block no_issues_name scoped %}No issues have been found.{% endblock %}
+{% block no_issues_name scoped %}
+*No issues have been found.*
+
+{% endblock %}
 {% endif %}
 
 {% endfor %}

--- a/mythx_cli/templates/layout.md
+++ b/mythx_cli/templates/layout.md
@@ -1,0 +1,12 @@
+{% block heading scoped %}{% endblock %}
+{% block preamble scoped %}{% endblock %}
+{% for status, report, input in issues_list %}
+{% if report %}
+{% block status scoped %}{% endblock %}
+{% block report scoped %}{% endblock %}
+{% else %}
+{% block no_issues_name scoped %}No issues have been found.{% endblock %}
+{% endif %}
+
+{% endfor %}
+{% block postamble scoped %}{% endblock %}

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -73,6 +73,6 @@ def test_renderer_group(ident, template):
 
 def test_invalid_id():
     runner = CliRunner()
-    result = runner.invoke(cli, ["--output=test.html", "render", "foo"])
+    result = runner.invoke(cli, ["--output=test.html", "render", "--aesthetic", "foo"])
     assert result.exception is not None
     assert result.exit_code == 2


### PR DESCRIPTION
One more bug to go:
```
$ mythx --output=test.md render --markdown 5E1860A3E129A700184D0075
Fetching report for analysis f8d61a90-50aa-4ccf-97e2-36779c21ad99
Fetching report for analysis 62371389-453e-403f-b2f5-b884e84143e4
Fetching report for analysis 418ece33-5ff5-4501-926c-85072910aaf0
Fetching report for analysis 29b9872d-d711-40df-8cf4-2f3c2d97257e
Fetching report for analysis a0135311-ba3a-47de-be7a-324603f9c528
Fetching report for analysis 4b4b48c9-629c-4c0a-afe8-e91e40466467
Fetching report for analysis 506e7e78-dffa-4adc-8c25-ac4ce5cb8bbb
Fetching report for analysis 8175fda5-7dc7-4ae7-b6c0-8d7effa01b28
Fetching report for analysis e67d31bc-342c-4bf0-ba62-722b568fa2ab
Fetching report for analysis b8d37700-9579-4da9-a60b-ea68d80a934d
Fetching report for analysis 8c87b560-5588-4547-886c-29936adab311
Fetching report for analysis 52a9c454-a5de-4239-8f23-1cee14bf2e2f
Fetching report for analysis 1b43ad4d-73a3-4abe-8cb8-3b5375cf55a1
Fetching report for analysis 870cf540-8407-46c4-82eb-cf2b2506849b
Fetching report for analysis e5e1a32f-89c9-4789-b8c4-61c0c78e7af7
Traceback (most recent call last):
  File "/home/spoons/diligence/tools/mythx-cli/venv/bin/mythx", line 11, in <module>
    load_entry_point('mythx-cli', 'console_scripts', 'mythx')()
  File "/home/spoons/diligence/tools/mythx-cli/mythx_cli/cli.py", line 72, in __call__
    return self.main(*args, **kwargs)
  File "/home/spoons/diligence/tools/mythx-cli/venv/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/spoons/diligence/tools/mythx-cli/venv/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/spoons/diligence/tools/mythx-cli/venv/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/spoons/diligence/tools/mythx-cli/venv/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/spoons/diligence/tools/mythx-cli/venv/lib/python3.7/site-packages/click/decorators.py", line 27, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/home/spoons/diligence/tools/mythx-cli/mythx_cli/cli.py", line 897, in render
    rendered = template.render(issues_list=issues_list, target=target)
  File "/home/spoons/diligence/tools/mythx-cli/venv/lib/python3.7/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/home/spoons/diligence/tools/mythx-cli/venv/lib/python3.7/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/home/spoons/diligence/tools/mythx-cli/venv/lib/python3.7/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "/home/spoons/diligence/tools/mythx-cli/mythx_cli/templates/default.md", line 1, in top-level template code
    {% extends "layout.md" %}
  File "/home/spoons/diligence/tools/mythx-cli/mythx_cli/templates/layout.md", line 6, in top-level template code
    {% block report scoped %}{% endblock %}
  File "/home/spoons/diligence/tools/mythx-cli/mythx_cli/templates/default.md", line 29, in block "report"
    **Line:** {{ location.start_line }}
  File "/home/spoons/diligence/tools/mythx-cli/venv/lib/python3.7/site-packages/jinja2/environment.py", line 471, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: list object has no element 2
```

Possibly related to decoded location parsing in the domain models or the template `{% set %}` statements