### PR TITLE
Feat/truffle inheritance

### DIFF
--- a/mythx_cli/analyze/truffle.py
+++ b/mythx_cli/analyze/truffle.py
@@ -25,8 +25,18 @@ class TruffleJob:
     def __init__(self, target: Path):
         self.target = target
         self.payloads = []
-        self.dependency_map = defaultdict(set)
         self.sol_artifact_map = {}
+        self.artifact_files, self.source_list = self.find_truffle_artifacts()
+
+        if not self.artifact_files:
+            raise click.exceptions.UsageError(
+                "Could not find any truffle artifacts. Did you run truffle compile?"
+            )
+        LOGGER.debug(
+            f"Detected Truffle project with files:{', '.join(self.artifact_files)}"
+        )
+
+        self.dependency_map = self.build_dependency_map()
 
     def find_truffle_artifacts(
         self
@@ -39,7 +49,6 @@ class TruffleJob:
 
         :return: Files under :code:`<project-dir>/build/contracts/` or :code:`None`
         """
-
         output_pattern = self.target / "build" / "contracts" / "*.json"
         artifact_files = list(glob(str(output_pattern.absolute())))
         if not artifact_files:
@@ -81,16 +90,7 @@ class TruffleJob:
 
         :return: The payload dictionary to be sent to MythX
         """
-
-        artifact_files, source_list = self.find_truffle_artifacts()
-
-        if not artifact_files:
-            raise click.exceptions.UsageError(
-                "Could not find any truffle artifacts. Did you run truffle compile?"
-            )
-        LOGGER.debug(f"Detected Truffle project with files:{', '.join(artifact_files)}")
-        self.build_dependency_map(artifact_files)
-        for file in artifact_files:
+        for file in self.artifact_files:
             with open(file) as af:
                 artifact = json.load(af)
                 LOGGER.debug(f"Loaded Truffle artifact with {len(artifact)} keys")
@@ -119,7 +119,7 @@ class TruffleJob:
                         },
                         **self.get_artifact_context(file),
                     },
-                    "source_list": source_list,
+                    "source_list": self.source_list,
                     "main_source": artifact.get("sourcePath"),
                     "solc_version": artifact["compiler"]["version"],
                 }
@@ -139,7 +139,26 @@ class TruffleJob:
         return re.sub(re.compile(r"__\w{38}"), "0" * 40, code)
 
     def artifact_to_sol_file(self, artifact_path):
-        # don't use lookup so we can resolve node_modules dependencies
+        """Resolve an artifact file to its corresponding Solidity file.
+
+        This method will take the Truffle artifact's file name, and
+        recursively search through the current directory and all
+        subdirectories, looking for a Solidity file with the same name.
+
+        For additional lookup performance in large Truffle projects with
+        a large dependency graph, the mapping from Solidity file to
+        artifact and vice versa is stored in the job object for future
+        resolution to aboid filesystem interaction.
+
+        NOTE: We do not loop up the entries in the mapping here, because
+        we want to avoid accidentally resolving external dependencies
+        defined by path remappings, e.g. @openzeppelin/SafeMath.sol as
+        these don't turn up as absolute paths in Truffle artifacts but
+        stay in the remapped format.
+
+        :param artifact_path: The path to the Truffle artifact
+        :return: The corresponding Solidity file path
+        """
         basename = Path(artifact_path).name.replace(".json", ".sol")
         sol_file = str(next(Path().rglob(basename)).absolute())
         self.sol_artifact_map[sol_file] = artifact_path
@@ -147,6 +166,19 @@ class TruffleJob:
         return sol_file
 
     def sol_file_to_artifact(self, sol_path, artifact_files):
+        """ Resolve a Solidity file to the corresponding artifact file.
+
+        This method will take the path to a Solidity file and return
+        its corresponding Truffle artifact JSON file.
+        If this relation is already stored in the local artifact mapping,
+        the result will be returned right away. Otherwise, the Solidity
+        path's file name is retrieved, and looked up in the list of
+        artifact files and add the relation to the job object's mapping.
+
+        :param sol_path: The path of the Solidity file to retrieve the artifact for
+        :param artifact_files: The list of artifact files in the Truffle build directory
+        :return: The resolved Truffle artifact JSON path
+        """
         if sol_path in self.sol_artifact_map:
             return self.sol_artifact_map[sol_path]
         basename = Path(sol_path).name.replace(".sol", ".json")
@@ -154,8 +186,19 @@ class TruffleJob:
         self.sol_artifact_map[sol_path] = artifact_path
         return artifact_path
 
-    def build_dependency_map(self, artifact_files):
-        for artifact_file in artifact_files:
+    def build_dependency_map(self):
+        """Build the local dependency mapping.
+
+        To speed up lookups when attaching related artifacts to analysis
+        payloads, this method builds a dependency map where the current
+        file is the key, and the value is a set containing all related
+        artifact paths the key file path depends on.
+
+        This method is called in the constructor to build the mapping right
+        away and speed up all future lookups.
+        """
+        dependency_map = defaultdict(set)
+        for artifact_file in self.artifact_files:
             with open(artifact_file) as af:
                 artifact = json.load(af)
 
@@ -163,12 +206,24 @@ class TruffleJob:
                 if node["nodeType"] != "ImportDirective":
                     continue
                 related_artifact = self.sol_file_to_artifact(
-                    node["absolutePath"], artifact_files
+                    node["absolutePath"], self.artifact_files
                 )
                 if related_artifact is not None:
-                    self.dependency_map[artifact_file].add(related_artifact)
+                    dependency_map[artifact_file].add(related_artifact)
+        return dependency_map
 
     def get_artifact_context(self, artifact_file):
+        """Get additional context for a given artifact file.
+
+        This method will look up the artifacts related to the current one
+        in the instace's dependency map, load their JSON, and attach source
+        code and AST information to the context object.
+
+        To do that, the related Solidity file path is resolved.
+
+        :param artifact_file: The artifact file to generate context for
+        :return: A dictionary containing source and AST information of all related files
+        """
         context = {}
         for related_file in self.dependency_map[artifact_file]:
             with open(related_file) as af:

--- a/mythx_cli/analyze/util.py
+++ b/mythx_cli/analyze/util.py
@@ -218,13 +218,12 @@ def is_valid_job(job) -> bool:
     elif not job.get("contract_name"):
         LOGGER.debug(f"Invalid job because contract name is {job.get('contract_name')}")
         valid = False
+    elif job.get("contract_name") == "Migrations":
+        LOGGER.debug("Invalid job because no one uses Migrations.sol, seriously.")
+        valid = False
 
     if not valid:
         # notify user
-        click.echo(
-            "Skipping submission for contract {} because no bytecode was produced.".format(
-                job.get("contract_name")
-            )
-        )
+        click.echo(f"Skipping submission for contract: {job.get('contract_name')}")
 
     return valid


### PR DESCRIPTION
This PR will expand on the existing payload generation for truffle artifacts by building a dependency list from related artifact files. Each dependency is then converted into a `source` map entry and attached to the original request so that with every submission, related files also end up at MythX for analysis, instead of previously only the artifact's source and AST.