### PR TITLE
Add solc path param and type hints

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,34 @@
 History
 =======
 
+0.6.20 (2020-09-05)
+-------------------
+
+- Add table sort key parameter
+- Fix bug where payloads were unnecessarily duplicated before filtering
+- Improve custom rendering documentation
+- Improve HTML/MD default template styles
+- Refactor and speed up template rendering routines
+- Add file-indexed formatting/rendering data structures
+- Add Scribble middleware to support Solidity and Truffle
+- Add Scribble JSON support for Solidity jobs
+- Refactor Solidity payload job
+- Add truffle payload context generation
+- Remove deprecated Sonarqube formatter
+
+- Update :code:`py-solc-x` to 1.0.0
+- Update :code:`pytest` to 6.0.1
+- Update :code:`pytest-cov` to 2.10.1
+- Update :code:`coveralls` to 2.1.2
+- Update :code:`coverage` to 5.2.1
+- Update :code:`sphinx` to 3.2.1
+- Update :code:`isort` to 5.5.1
+- Update :code:`tox` to 3.20.0
+- Update :code:`watchdog` to 0.10.3
+- Update :code:`twine` to 3.2.0
+
+
+
 0.6.19 (2020-06-23)
 -------------------
 
@@ -27,7 +55,6 @@ History
 - Refresh payload documentation
 - Refactor payload-related tests
 - Update :code:`py-solc-x` to 0.9.0
-- Update :code:`5.4.3`
 - Update :code:`sphinx` to 3.1.1
 - Update :code:`pytest-cov` to 2.10.0
 - Update :code:`tox` to 3.15.2

--- a/docs/mythx_cli.rst
+++ b/docs/mythx_cli.rst
@@ -33,7 +33,6 @@ mythx\_cli.util module
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -220,18 +220,23 @@ By default, it will print a tabular representation of the report to stdout:
 
     Report for /home/circleci/project/contracts/token.sol
     https://dashboard.mythx.io/#/console/analyses/f9e69a6a-2339-43b0-ad03-125c6cf81a70
-    ╒════════╤═══════════════════════════════════╤════════════╤═══════════════════════════════════════════╕
-    │   Line │ SWC Title                         │ Severity   │ Short Description                         │
-    ╞════════╪═══════════════════════════════════╪════════════╪═══════════════════════════════════════════╡
-    │     14 │ Integer Overflow and Underflow    │ High       │ The binary addition can overflow.         │
-    ├────────┼───────────────────────────────────┼────────────┼───────────────────────────────────────────┤
-    │     13 │ Integer Overflow and Underflow    │ High       │ The binary subtraction can underflow.     │
-    ├────────┼───────────────────────────────────┼────────────┼───────────────────────────────────────────┤
-    │      1 │ Floating Pragma                   │ Low        │ A floating pragma is set.                 │
-    ├────────┼───────────────────────────────────┼────────────┼───────────────────────────────────────────┤
-    │      5 │ State Variable Default Visibility │ Low        │ The state variable visibility is not set. │
-    ╘════════╧═══════════════════════════════════╧════════════╧═══════════════════════════════════════════╛
+    ╒════════╤═════════════════════════════════════════════╤════════════╤════════════════════════════════════════╕
+    │   Line │ SWC Title                                   │ Severity   │ Short Description                      │
+    ╞════════╪═════════════════════════════════════════════╪════════════╪════════════════════════════════════════╡
+    │      1 │ (SWC-103) Floating Pragma                   │ Low        │ A floating pragma is set.              │
+    ├────────┼─────────────────────────────────────────────┼────────────┼────────────────────────────────────────┤
+    │      3 │ (SWC-000) Unknown                           │ Medium     │ Incorrect ERC20 implementation         │
+    ├────────┼─────────────────────────────────────────────┼────────────┼────────────────────────────────────────┤
+    │      5 │ (SWC-108) State Variable Default Visibility │ Low        │ State variable visibility is not set.  │
+    ├────────┼─────────────────────────────────────────────┼────────────┼────────────────────────────────────────┤
+    │     13 │ (SWC-101) Integer Overflow and Underflow    │ High       │ The arithmetic operator can underflow. │
+    ├────────┼─────────────────────────────────────────────┼────────────┼────────────────────────────────────────┤
+    │     14 │ (SWC-101) Integer Overflow and Underflow    │ High       │ The arithmetic operator can overflow.  │
+    ╘════════╧═════════════════════════════════════════════╧════════════╧════════════════════════════════════════╛
 
+This table by default is sorted by line number. If another sorting is required,
+the user can specify e.g. :code:`--table-sort-key=severity` to sort by alphabetically by the
+severity column.
 
 The :code:`simple` format option will also resolve the report's source map
 locations to the corresponding line and column numbers in the Solidity

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -84,6 +84,7 @@ Submitting Analyses
       --swc-blacklist TEXT           A comma-separated list of SWC IDs to ignore
       --swc-whitelist TEXT           A comma-separated list of SWC IDs to include
       --solc-version TEXT            The solc version to use for compilation
+      --solc-path PATH               Path to a custom solc executable
       --include TEXT                 The contract name(s) to submit to MythX
       --remap-import TEXT            Add a solc compilation import remapping
       --check-properties             Enable property verification mode
@@ -128,7 +129,11 @@ This will increase the number of detected issues (as e.g. symbolic execution
 tools in the MythX backend can pick up on the bytecode), as well as reduce
 the number of false positive issues. The MythX CLI will try to infer the
 :code:`solc` version based on the pragma set in the source code. An explicit
-compiler version can be specified with the :code:`--solc-version` flag.
+compiler version can be specified with the :code:`--solc-version` flag. If
+:code:`solc` is already installed, an existing executable can be passed to the
+CLI by specifying :code:`--solc-path`. Please note that this only works with
+a compiled :code:`solc` binary and not with executable wrappers such as
+:code:`solcjs` due to differences in their interfaces.
 
 By default, the MythX CLI will submit the bytecode of the target contract
 (if specified), and add the source code and AST information of its

--- a/mythx_cli/analyze/command.py
+++ b/mythx_cli/analyze/command.py
@@ -85,6 +85,12 @@ LOGGER = logging.getLogger("mythx-cli")
     default=None,
 )
 @click.option(
+    "--solc-path",
+    type=click.Path(exists=True),
+    default=None,
+    help="Path to a custom solc executable",
+)
+@click.option(
     "--include",
     type=click.STRING,
     multiple=True,
@@ -136,6 +142,7 @@ def analyze(
     swc_blacklist: str,
     swc_whitelist: str,
     solc_version: str,
+    solc_path: str,
     include: Tuple[str],
     remap_import: Tuple[str],
     check_properties: bool,
@@ -158,6 +165,7 @@ def analyze(
     :param swc_blacklist: A comma-separated list of SWC IDs to ignore
     :param swc_whitelist: A comma-separated list of SWC IDs to include
     :param solc_version: The solc version to use for Solidity compilation
+    :param solc_path: The path to a custom solc executable
     :param include: List of contract names to send - exclude everything else
     :param remap_import: List of import remappings to pass on to solc
     :param check_properties: Enable property verification mode
@@ -225,6 +233,7 @@ def analyze(
             jobs.extend(
                 SolidityJob.walk_solidity_files(
                     solc_version,
+                    solc_path=solc_path,
                     base_path=element,
                     remappings=remap_import,
                     enable_scribble=enable_scribble,
@@ -241,6 +250,7 @@ def analyze(
             job = SolidityJob(Path(file_path))
             job.generate_payloads(
                 version=solc_version,
+                solc_path=solc_path,
                 contract=contract or None,
                 remappings=remap_import,
                 enable_scribble=enable_scribble,

--- a/mythx_cli/analyze/command.py
+++ b/mythx_cli/analyze/command.py
@@ -232,7 +232,7 @@ def analyze(
             LOGGER.debug(f"Identified {element} as directory containing Solidity files")
             jobs.extend(
                 SolidityJob.walk_solidity_files(
-                    solc_version,
+                    solc_version=solc_version,
                     solc_path=solc_path,
                     base_path=element,
                     remappings=remap_import,

--- a/mythx_cli/analyze/solidity.py
+++ b/mythx_cli/analyze/solidity.py
@@ -1,10 +1,7 @@
 """This module contains functions to generate Solidity-related payloads."""
 
-import json
 import logging
 import re
-import subprocess
-import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -25,7 +22,7 @@ class SolidityJob(ScribbleMixin):
         self.target = str(target)
         self.payloads = []
 
-    def payload_from_sources(self, solc_result, scribble_file, solc_version):
+    def payload_from_sources(self, solc_result: Dict, scribble_file: str, solc_version: str) -> Dict:
         compiled_sources = solc_result.get("sources", {})
         payload = {
             "sources": {},
@@ -56,7 +53,7 @@ class SolidityJob(ScribbleMixin):
 
         return payload
 
-    def solc_version_from_source(self, source, default_version):
+    def solc_version_from_source(self, source: str, default_version: str):
         solc_version = re.findall(PRAGMA_PATTERN, source)
         LOGGER.debug(f"solc version matches in {self.target}: {solc_version}")
 
@@ -69,7 +66,7 @@ class SolidityJob(ScribbleMixin):
         return f"v{default_version or solc_version[0]}"
 
     @staticmethod
-    def setup_solcx(solc_version):
+    def setup_solcx(solc_version: str):
         if solc_version not in solcx.get_installed_solc_versions():
             try:
                 LOGGER.debug(f"Installing solc {solc_version}")
@@ -104,7 +101,7 @@ class SolidityJob(ScribbleMixin):
 
         return payload
 
-    def set_payload_bytecode_context(self, payload, solc_result):
+    def set_payload_bytecode_context(self, payload: Dict, solc_result: Dict):
         # extract the largest bytecode from the compilation result and add it
         bytecode_max = 0
         for file_path, file_element in solc_result.get("contracts", {}).items():
@@ -128,7 +125,7 @@ class SolidityJob(ScribbleMixin):
                     )
                     payload["deployed_source_map"] = contract_deployed_source_map
 
-    def solcx_compile(self, path: str, remappings: Tuple[str], enable_scribble: bool, scribble_file: str = None, solc_path: str = None):
+    def solcx_compile(self, path: str, remappings: Tuple[str], enable_scribble: bool, scribble_file: str = None, solc_path: str = None) -> Dict:
         return solcx.compile_standard(
             solc_binary=solc_path,
             input_data={
@@ -205,7 +202,7 @@ class SolidityJob(ScribbleMixin):
 
         if enable_scribble:
             # use scribble for compilation
-            result = self.instrument_solc_file(self.target, scribble_path, remappings)
+            result = self.instrument_solc_file(target=self.target, scribble_path=scribble_path, remappings=remappings)
         else:
             # use solc for compilation
             self.setup_solcx(solc_version)

--- a/mythx_cli/analyze/solidity.py
+++ b/mythx_cli/analyze/solidity.py
@@ -205,9 +205,12 @@ class SolidityJob(ScribbleMixin):
         with open(self.target) as f:
             source = f.read()
 
-        solc_version = self.solc_version_from_source(
-            source=source, default_version=version
-        )
+        solc_version = None
+        if solc_path is None:
+            solc_version = self.solc_version_from_source(
+                source=source, default_version=version
+            )
+            self.setup_solcx(solc_version)
 
         if enable_scribble:
             # use scribble for compilation
@@ -215,8 +218,6 @@ class SolidityJob(ScribbleMixin):
                 target=self.target, scribble_path=scribble_path, remappings=remappings
             )
         else:
-            # use solc for compilation
-            self.setup_solcx(solc_version)
             try:
                 cwd = str(Path.cwd().absolute())
                 LOGGER.debug(f"Compiling {self.target} under allowed path {cwd}")

--- a/mythx_cli/analyze/solidity.py
+++ b/mythx_cli/analyze/solidity.py
@@ -252,8 +252,9 @@ class SolidityJob(ScribbleMixin):
                 return
             except KeyError:
                 LOGGER.warning(
-                    f"Could not find contract {contract} in compilation artifacts. The CLI will find the "
-                    f"largest bytecode artifact in the compilation output and submit it instead."
+                    f"Could not find contract {contract} in compilation artifacts. The CLI will "
+                    f"find the largest bytecode artifact in the compilation output and submit it "
+                    f"instead."
                 )
 
         self.set_payload_bytecode_context(payload, result)

--- a/mythx_cli/analyze/solidity.py
+++ b/mythx_cli/analyze/solidity.py
@@ -22,7 +22,9 @@ class SolidityJob(ScribbleMixin):
         self.target = str(target)
         self.payloads = []
 
-    def payload_from_sources(self, solc_result: Dict, scribble_file: str, solc_version: str) -> Dict:
+    def payload_from_sources(
+        self, solc_result: Dict, scribble_file: str, solc_version: str
+    ) -> Dict:
         compiled_sources = solc_result.get("sources", {})
         payload = {
             "sources": {},
@@ -125,7 +127,14 @@ class SolidityJob(ScribbleMixin):
                     )
                     payload["deployed_source_map"] = contract_deployed_source_map
 
-    def solcx_compile(self, path: str, remappings: Tuple[str], enable_scribble: bool, scribble_file: str = None, solc_path: str = None) -> Dict:
+    def solcx_compile(
+        self,
+        path: str,
+        remappings: Tuple[str],
+        enable_scribble: bool,
+        scribble_file: str = None,
+        solc_path: str = None,
+    ) -> Dict:
         return solcx.compile_standard(
             solc_binary=solc_path,
             input_data={
@@ -202,14 +211,21 @@ class SolidityJob(ScribbleMixin):
 
         if enable_scribble:
             # use scribble for compilation
-            result = self.instrument_solc_file(target=self.target, scribble_path=scribble_path, remappings=remappings)
+            result = self.instrument_solc_file(
+                target=self.target, scribble_path=scribble_path, remappings=remappings
+            )
         else:
             # use solc for compilation
             self.setup_solcx(solc_version)
             try:
                 cwd = str(Path.cwd().absolute())
                 LOGGER.debug(f"Compiling {self.target} under allowed path {cwd}")
-                result = self.solcx_compile(path=cwd, remappings=remappings, enable_scribble=enable_scribble, solc_path=solc_path)
+                result = self.solcx_compile(
+                    path=cwd,
+                    remappings=remappings,
+                    enable_scribble=enable_scribble,
+                    solc_path=solc_path,
+                )
             except solcx.exceptions.SolcError as e:
                 raise click.exceptions.UsageError(
                     f"Error compiling source with solc {solc_version}: {e}"

--- a/mythx_cli/analyze/truffle.py
+++ b/mythx_cli/analyze/truffle.py
@@ -19,9 +19,9 @@ LOGGER = logging.getLogger("mythx-cli")
 class TruffleJob(ScribbleMixin):
     """A truffle job to be sent to the API.
 
-    This object represents a collection of truffle artifacts that will be sent
-    to the API. It aggregates artifacts and transforms them into API-conform
-    payload dicts.
+    This object represents a collection of truffle artifacts that will
+    be sent to the API. It aggregates artifacts and transforms them into
+    API-conform payload dicts.
     """
 
     def __init__(self, target: Path):

--- a/mythx_cli/analyze/truffle.py
+++ b/mythx_cli/analyze/truffle.py
@@ -7,7 +7,7 @@ import sys
 from collections import defaultdict
 from glob import glob
 from pathlib import Path
-from typing import List, Set, Tuple, Union
+from typing import List, Set, Tuple, Union, Optional, Any, Dict, Iterable
 
 import click
 
@@ -139,7 +139,7 @@ class TruffleJob(ScribbleMixin):
 
         if enable_scribble:
             return self.instrument_truffle_artifacts(
-                self.payloads, scribble_path, remappings
+                payloads=self.payloads, scribble_path=scribble_path, remappings=remappings
             )
         else:
             return self.payloads
@@ -157,7 +157,7 @@ class TruffleJob(ScribbleMixin):
         """
         return re.sub(re.compile(r"__\w{38}"), "0" * 40, code)
 
-    def artifact_to_sol_file(self, artifact_path):
+    def artifact_to_sol_file(self, artifact_path: str) -> str:
         """Resolve an artifact file to its corresponding Solidity file.
 
         This method will take the Truffle artifact's file name, and
@@ -184,7 +184,7 @@ class TruffleJob(ScribbleMixin):
         self.sol_artifact_map[artifact_path] = sol_file
         return sol_file
 
-    def sol_file_to_artifact(self, sol_path: str, artifact_files: Tuple[List[str], List[str]]):
+    def sol_file_to_artifact(self, sol_path: str, artifact_files: Tuple[List[str], List[str]]) -> Optional[List[str]]:
         """Resolve a Solidity file to the corresponding artifact file.
 
         This method will take the path to a Solidity file and return
@@ -205,7 +205,7 @@ class TruffleJob(ScribbleMixin):
         self.sol_artifact_map[sol_path] = artifact_path
         return artifact_path
 
-    def build_dependency_map(self):
+    def build_dependency_map(self) -> Dict[Any, Iterable]:
         """Build the local dependency mapping.
 
         To speed up lookups when attaching related artifacts to analysis
@@ -225,13 +225,13 @@ class TruffleJob(ScribbleMixin):
                 if node["nodeType"] != "ImportDirective":
                     continue
                 related_artifact = self.sol_file_to_artifact(
-                    node["absolutePath"], self.artifact_files
+                    sol_path=node["absolutePath"], artifact_files=self.artifact_files
                 )
                 if related_artifact is not None:
                     dependency_map[artifact_file].add(related_artifact)
         return dependency_map
 
-    def get_artifact_context(self, artifact_file):
+    def get_artifact_context(self, artifact_file: str) -> Dict[str, Any]:
         """Get additional context for a given artifact file.
 
         This method will look up the artifacts related to the current one
@@ -247,7 +247,7 @@ class TruffleJob(ScribbleMixin):
         for related_file in self.dependency_map[artifact_file]:
             with open(related_file) as af:
                 artifact = json.load(af)
-            context[self.artifact_to_sol_file(related_file)] = {
+            context[self.artifact_to_sol_file(artifact_path=related_file)] = {
                 "source": artifact.get("source"),
                 "ast": artifact.get("ast"),
             }

--- a/mythx_cli/analyze/truffle.py
+++ b/mythx_cli/analyze/truffle.py
@@ -7,7 +7,7 @@ import sys
 from collections import defaultdict
 from glob import glob
 from pathlib import Path
-from typing import List, Set, Tuple, Union, Optional, Any, Dict, Iterable
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import click
 
@@ -139,7 +139,9 @@ class TruffleJob(ScribbleMixin):
 
         if enable_scribble:
             return self.instrument_truffle_artifacts(
-                payloads=self.payloads, scribble_path=scribble_path, remappings=remappings
+                payloads=self.payloads,
+                scribble_path=scribble_path,
+                remappings=remappings,
             )
         else:
             return self.payloads
@@ -184,7 +186,9 @@ class TruffleJob(ScribbleMixin):
         self.sol_artifact_map[artifact_path] = sol_file
         return sol_file
 
-    def sol_file_to_artifact(self, sol_path: str, artifact_files: Tuple[List[str], List[str]]) -> Optional[List[str]]:
+    def sol_file_to_artifact(
+        self, sol_path: str, artifact_files: Tuple[List[str], List[str]]
+    ) -> Optional[List[str]]:
         """Resolve a Solidity file to the corresponding artifact file.
 
         This method will take the path to a Solidity file and return

--- a/mythx_cli/analyze/truffle.py
+++ b/mythx_cli/analyze/truffle.py
@@ -184,7 +184,7 @@ class TruffleJob(ScribbleMixin):
         self.sol_artifact_map[artifact_path] = sol_file
         return sol_file
 
-    def sol_file_to_artifact(self, sol_path, artifact_files):
+    def sol_file_to_artifact(self, sol_path: str, artifact_files: Tuple[List[str], List[str]]):
         """Resolve a Solidity file to the corresponding artifact file.
 
         This method will take the path to a Solidity file and return

--- a/mythx_cli/formatter/json.py
+++ b/mythx_cli/formatter/json.py
@@ -19,8 +19,8 @@ from mythx_cli.formatter.base import BaseFormatter
 class JSONFormatter(BaseFormatter):
     """The JSON formatter.
 
-    It returns string-encoded JSON objects and does not require the analysis
-    input to generate payloads.
+    It returns string-encoded JSON objects and does not require the
+    analysis input to generate payloads.
     """
 
     report_requires_input = False
@@ -71,9 +71,9 @@ class JSONFormatter(BaseFormatter):
 class PrettyJSONFormatter(BaseFormatter):
     """The pretty-printing JSON formatter.
 
-    It works exactly as the JSON formatter, with the difference that the string-
-    encoded JSON object is indented with two spaces for each level, and the keys
-    are sorted in alphabetical order.
+    It works exactly as the JSON formatter, with the difference that the
+    string- encoded JSON object is indented with two spaces for each
+    level, and the keys are sorted in alphabetical order.
     """
 
     report_requires_input = False

--- a/mythx_cli/formatter/simple_stdout.py
+++ b/mythx_cli/formatter/simple_stdout.py
@@ -20,9 +20,10 @@ from mythx_cli.util import index_by_filename
 class SimpleFormatter(BaseFormatter):
     """The simple text formatter.
 
-    This formatter generates simplified text output. It also displays the source
-    locations of issues by line in the Solidity source code if given. Therefore,
-    this formatter requires the analysis input to be given.
+    This formatter generates simplified text output. It also displays
+    the source locations of issues by line in the Solidity source code
+    if given. Therefore, this formatter requires the analysis input to
+    be given.
     """
 
     report_requires_input = True

--- a/mythx_cli/formatter/tabular.py
+++ b/mythx_cli/formatter/tabular.py
@@ -25,9 +25,10 @@ class TabularFormatter(BaseFormatter):
     """The tabular formatter.
 
     This formatter displays an ASCII table. It is enabled by default and
-    requires the analysis input data to display each issue's line number in the
-    source file. It might break on very large field sizes as cell-internal line
-    breaks are not supported by the tabulate library yet.
+    requires the analysis input data to display each issue's line number
+    in the source file. It might break on very large field sizes as
+    cell-internal line breaks are not supported by the tabulate library
+    yet.
     """
 
     report_requires_input = True

--- a/mythx_cli/formatter/util.py
+++ b/mythx_cli/formatter/util.py
@@ -59,12 +59,12 @@ def normalize_swc_list(swc_list: Union[str, List[str], None]) -> List[str]:
 def set_ci_failure() -> None:
     """Based on the current context, set the return code to 1.
 
-    This method sets the return code to 1. It is called by the respective
-    subcommands (analyze and report) in case a severe issue has been found (as
-    specified by the user) if the CI flag is passed. This will make the MythX
-    CLI fail when running on a CI server. If no context is available, this
-    function assumes that it is running outside a CLI scenario (e.g. a test
-    setup) and will not do anything.
+    This method sets the return code to 1. It is called by the
+    respective subcommands (analyze and report) in case a severe issue
+    has been found (as specified by the user) if the CI flag is passed.
+    This will make the MythX CLI fail when running on a CI server. If no
+    context is available, this function assumes that it is running
+    outside a CLI scenario (e.g. a test setup) and will not do anything.
     """
     try:
         ctx = click.get_current_context()

--- a/mythx_cli/render/util.py
+++ b/mythx_cli/render/util.py
@@ -21,10 +21,10 @@ def get_analysis_info(
 ) -> Tuple[AnalysisStatusResponse, DetectedIssuesResponse, AnalysisInputResponse]:
     """Fetch information related to the specified analysis job UUID.
 
-    Given a UUID, this function will query the MythX API for the analysis
-    status, the analysis' input data, and the issue report. Furthermore,
-    filtering parameters can be passed to remove certain SWCs or severities from
-    the returned report.
+    Given a UUID, this function will query the MythX API for the
+    analysis status, the analysis' input data, and the issue report.
+    Furthermore, filtering parameters can be passed to remove certain
+    SWCs or severities from the returned report.
     """
 
     LOGGER.debug(f"{uuid}: Fetching report")

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,3 @@ universal = 1
 
 [aliases]
 test = pytest
-
-[tool:pytest]
-collect_ignore = ['setup.py', 'tests/testdata/*']
-


### PR DESCRIPTION
This PR will:
- add a `solc-path` parameter allowing a user to specify a custom solc binary for compilation
- introduce more type hints for easier development
- add named parameters to future-proof function headers