### PR TITLE
Add support for Scribble instrumentation metadata for a Fuzz feature

### DIFF
--- a/mythx_cli/analyze/scribble.py
+++ b/mythx_cli/analyze/scribble.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 import sys
 from collections import defaultdict
@@ -6,6 +7,7 @@ from typing import List
 
 import click
 
+SCRIBBLE_ARMING_META_FILE = ".scribble-arming.meta.json"
 
 class ScribbleMixin:
     """A mixing for job objects to instrument code with Scribble."""
@@ -27,6 +29,7 @@ class ScribbleMixin:
         click.echo(process.stderr.decode())
         click.echo("=====STDOUT=====")
         click.echo(process.stdout.decode())
+
         sys.exit(process.returncode)
 
     def instrument_truffle_artifacts(
@@ -49,6 +52,7 @@ class ScribbleMixin:
                     "source": file_data["source"],
                     "id": payload["source_list"].index(filename),
                 }
+
                 stdin["contracts"][filename][payload["contract_name"]] = {
                     "evm": {
                         "bytecode": {
@@ -72,6 +76,7 @@ class ScribbleMixin:
         )
 
         self._handle_scribble_error(process)
+
         return json.loads(process.stdout.decode())
 
     def instrument_solc_file(
@@ -91,7 +96,9 @@ class ScribbleMixin:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
+
         self._handle_scribble_error(process)
+
         return json.loads(process.stdout.decode())
 
     @staticmethod
@@ -108,17 +115,25 @@ class ScribbleMixin:
         :param remappings: List of import remappings to pass to solc
         :param solc_version: The solc compiler version to use
         """
+        command = [
+            scribble_path,
+            "--arm",
+            "--output-mode=files",
+            f"--instrumentation-metadata-file={SCRIBBLE_ARMING_META_FILE}"
+        ]
 
-        command = [scribble_path, "--arm", "--output-mode=files"]
         if remappings:
             command.append(f"--path-remapping={';'.join(remappings)}")
+
         if solc_version:
             command.append(f"--compiler-version={solc_version}")
+
         command.extend(file_list)
 
         process = subprocess.run(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
+
         ScribbleMixin._handle_scribble_error(process)
 
     @staticmethod
@@ -135,15 +150,29 @@ class ScribbleMixin:
         :param remappings: List of import remappings to pass to solc
         :param solc_version: The solc compiler version to use
         """
-
         command = [scribble_path, "--disarm"]
+
         if remappings:
             command.append(f"--path-remapping={';'.join(remappings)}")
+
         if solc_version:
             command.append(f"--compiler-version={solc_version}")
+
         command.extend(file_list)
+
+        if os.path.isfile(SCRIBBLE_ARMING_META_FILE):
+            os.remove(SCRIBBLE_ARMING_META_FILE)
 
         process = subprocess.run(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
+
         ScribbleMixin._handle_scribble_error(process)
+
+    @staticmethod
+    def get_arming_instr_meta():
+        if os.path.exists(SCRIBBLE_ARMING_META_FILE):
+            with open(SCRIBBLE_ARMING_META_FILE, 'r') as f:
+                return json.load(f)
+
+        return None

--- a/mythx_cli/fuzz/run.py
+++ b/mythx_cli/fuzz/run.py
@@ -6,6 +6,8 @@ import click
 import json
 from .brownie import  BrownieJob
 
+from mythx_cli.analyze.scribble import ScribbleMixin
+
 LOGGER = logging.getLogger("mythx-cli")
 
 rpc_url = "http://localhost:7545"
@@ -120,6 +122,11 @@ def fuzz_run(ctx, address, more_addresses, target):
     brownie.generate_payload(seed_state)
 
     api_payload = brownie.payload
+    instr_meta = ScribbleMixin.get_arming_instr_meta()
+
+    if instr_meta is not None:
+        api_payload["instrumentation_metadata"] = instr_meta
+
     print(json.dumps(api_payload))
 
 pass


### PR DESCRIPTION
## Changes
- Tweaked `ScribbleMixin` to use `--instrumentation-metadata-file` option of Scribble and store metadata at path of  `SCRIBBLE_ARMING_META_FILE` constant (for now it is `.scribble-arming.meta.json` in the CWD). Arming is generating the metadata file. Disarming will remove it.
- Introduced `ScribbleMixin.get_arming_instr_meta()` static method for an convenient access to the generated metadata file contents in other classes.
- Tweaked `fuzz_run` to add (if present) data from `ScribbleMixin.get_arming_instr_meta()` to the submission payload.

## Notes
I guess it would be better to add a CLI option to override output location for a generated metadata. The current value (`.scribble-arming.meta.json` in constant `SCRIBBLE_ARMING_META_FILE`) can be used as a default.

## Related links
- [Scribble instrumentation metadata format description](https://docs.scribble.codes/tool/json-output-specification#instrumentation-metadata)
- [Scribble instrumentation metadata generation options via CLI](https://docs.scribble.codes/tool/instrumented-code#property-maps)

Regards.