### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tabulate==0.8.9
 Jinja2==2.11.3
 htmlmin==0.1.12
 PyYAML==5.4.1
+MarkupSafe==2.0.1


### PR DESCRIPTION
MarkupSafe 2.1.0 no longer has soft_unicode , as such, it breaks